### PR TITLE
Adapt to hash compatibly with draft standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Prove It!
 =========
 
-This is a basic implementation of gmaxwell's suggestion of proving account balances documented here: https://iwilcox.me.uk/v/nofrac
+This is a basic implementation of gmaxwell's suggestion of proving
+account balances documented here:
+https://iwilcox.me.uk/2014/proving-bitcoin-reserves
 
 This will work for any CryptoCurrency that is based off the Bitcoin protocol.
 
@@ -12,15 +14,28 @@ To install the project just use:
 pip install proveit
 ```
 
-You will need to provide the HashTree class with a list of customer accounts and hashes with which to create a glorified Merkle tree.
+You will need to provide the HashTree class with a list of customer
+balances, user-chosen tokens such as username/e-mail and nonces with
+which to create a glorified Merkle tree.
 
-The hashes should probably just be hashfunction(customer_id + salt), or something of the like.
+You can supply a manually computed hash instead, in which case you
+should consider generating it in way that's [compatible with other
+implementations] [s11n] (the default hashing used if you supply
+uids/nonces is already compatible).
+
+ [s11n]: https://github.com/olalonde/proof-of-liabilities#serialized-data-formats-work-in-progress--draft
 
 #### Basic Usage
 ```python
 from proveit import *
 
-customers = [ Node(123, 'unique identifier, preferably hashed'), Node(456, 'unique identifier2, preferably hashed as well')]
+customers = [ Node(nsum=123, uid='unique user-chosen identifier', nonce='secret shared with exchange'),
+              Node(nsum=456, uid='another unique user-chosen id', nonce='another secret shared with exchange')]
+
+# Alternatively:
+
+customers = [ Node(nsum=123, nhash='externally computed hash, preferably produced compatibly'),
+              Node(nsum=456, nhash='another externally computed hash, preferably produced compatibly')]
 
 hashtree = HashTree(customers)
 ```
@@ -30,15 +45,15 @@ Now you've generated a hashtree where any customer can validate that you've incl
 All you need to do to provide them with the relevant information follows:
 
 ```python
-info = hashtree.GetInfoFromHash('unique identifier, preferably hashed')
+info = hashtree.GetInfoFromHash('hash')
 ```
 
-This provides (Account Value, Identifier, root hash, Hash Tree)
+This provides (account balance, account hash, root hash, partial hash tree)
 
 Now anyone can verify this section of the Merkle tree using the following function.
 
 ```python
-ValidateNode(Node(info[0], info[1]), info[2], info[3])
+ValidateNode(Node(nsum=123, uid='user-chosen id', nonce='secret shared with exchange'), info[2], info[3])
 ```
 
 To add the CryptoCurrency portion of the account verification, use the following code, inserting your own RPC information as required.

--- a/testit.py
+++ b/testit.py
@@ -1,29 +1,45 @@
 from proveit import *
-import os, random
-from hashlib import sha256
+import random
+import string
+
+NONCE_BITS=128
+NYBBLE_BITS=4
+HEX_DIGITS="0123456789abcdef"
+
+def RandomWord(alphabet, n):
+	r = random.SystemRandom()
+	return ''.join([r.choice(list(alphabet)) for i in range(n)])
 
 def RandomNode():
-	value = random.uniform(0, 1000)
-	hashdigest = sha256(os.urandom(32)).hexdigest()
-	return value, hashdigest
+	uid = RandomWord(string.ascii_lowercase, 8)
+	nsum = random.uniform(0, 1000)
+	nonce = RandomWord(HEX_DIGITS, NONCE_BITS/NYBBLE_BITS)
+	return uid, nsum, nonce
 
 def RandomNodeList(n=20):
 	nodelist = []
 	for x in range(n):
 		result = RandomNode()
-		nodelist.append(Node(result[0], result[1]))
+		nodelist.append(Node(nsum=result[1], uid=result[0], nonce=result[2]))
 	return nodelist
-
 
 if __name__=='__main__':
 	nodelist = RandomNodeList(n=40)
-	h = HashTree(nodelist)
-	print h.ReturnTotal()
 	total = 0
+
+	print "Accounts:"
 	for x in nodelist:
-		total += x.value
-	print total
-	for x in range(40):
+		total += x.sum
+		print str(x)
+	print "Expected total: {:f}".format(total)
+
+	print
+	h = HashTree(nodelist)
+	print "Tree total:     {:f}".format(h.ReturnTotal())
+	print "Tree root hash: " + str(h.roothash)
+
+	for x in range(len(nodelist)):
 		info = h.GetNodeInfo(x)
 		pairlist = h.GetNodePairList(x)
-		print ValidateNode(Node(info[0], info[1]), pairlist[0], pairlist[1])
+		included = ValidateNode(nodelist[x], pairlist[0], pairlist[1])
+		print "Inclusion verified " + str(included) + " for node " + str(nodelist[x])


### PR DESCRIPTION
Namely [this one](https://github.com/olalonde/proof-of-liabilities#serialized-data-formats-work-in-progress--draft) which you've raised no objections to and hopefully approve of! :)

This is with a view to adding support for JSON de/serialisation in a further pull request.

Also:
- accept uid/nonce as alternative to externally produced hash, to encourage
  standard hashing format
- be sure to provide original data to validation, rather than feeding
  data obtained from tree right back in
- use `sum` not `value`, and `hash` not `hashdigest`, (where that doesn't
  conflict with builtins) to match terminology in standard and in other implementations
- update README to match, including suggesting following draft standard
- change test to construct `Node` with uid/nonce leaves, since internal node
  hashing already tests externally-provided-hash constructor
- add `__str__` for slightly pretty-printing `Node`
- be more verbose in test output
- update link to point to preferred, more verbose/pretty description
